### PR TITLE
Fix move-to-section; add deadlines + label updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,22 @@ todoist tasks -p "Work"  # Tasks in project
 todoist tasks -f "p1"    # Filter query (priority 1)
 
 todoist add "Task" -d "tomorrow" -P 1 -p "Work" -l "urgent"
+todoist add "Task" -p "Work" --deadline "2026-03-05"
 todoist add "Task at top" -p "Work" --top
 todoist add "Task at position 3" -p "Work" --order 3
 todoist add "Assigned task" -a "user-id"  # Assign to user
 todoist view <id>        # View task details
 todoist update <id> --due "next week"
+todoist update <id> --deadline "2026-03-05"
+todoist update <id> --deadline none          # Clear deadline
+todoist update <id> --labels "next,waiting" # Replace labels
+todoist update <id> --add-label next --remove-label waiting
 todoist update <id> -a "user-id"        # Assign task
 todoist update <id> -a "null"           # Unassign task
 todoist done <id>        # Complete task
 todoist reopen <id>      # Reopen completed task
-todoist move <id> -p "Personal"  # Move to project
+todoist move <id> -p "Personal"                 # Move to project
+todoist move <id> -p "Work" -s "Section A"      # Move to section
 todoist delete <id>      # Delete task
 todoist search "keyword" # Search tasks
 ```
@@ -114,7 +120,7 @@ Global flags available on all commands:
 | `-h, --help` | Show help |
 | `-V, --version` | Show version number |
 | `--no-color` | Disable colored output |
-| `--json` | Output as JSON (where applicable) |
+| `--json` | Output as JSON (where applicable; not supported by every command) |
 
 ## Environment Variables
 
@@ -139,6 +145,7 @@ Global flags available on all commands:
 ```bash
 todoist add "Review PR" \
   --due "tomorrow 10am" \
+  --deadline "2026-03-05" \
   --priority 2 \
   --project "Work" \
   --label "dev" \
@@ -147,6 +154,29 @@ todoist add "Review PR" \
 # Add task to a specific position in a project/section
 todoist add "Triage inbox" --order top
 todoist add "Triage inbox" --order 2
+```
+
+### Update labels
+
+```bash
+# Replace all labels
+todoist update <id> --labels "next,waiting"
+
+# Or apply incremental changes
+todoist update <id> --add-label next --remove-label waiting
+```
+
+### Deadlines
+
+```bash
+todoist update <id> --deadline "2026-03-05"
+todoist update <id> --deadline none  # clear
+```
+
+### Move to a section
+
+```bash
+todoist move <id> -p "Work" -s "Section A"
 ```
 
 ### Filter tasks by priority

--- a/src/deadline.ts
+++ b/src/deadline.ts
@@ -1,0 +1,38 @@
+export type DeadlineParseResult = {
+  deadlineDate?: string | null;
+  error?: string;
+};
+
+export type DeadlineDateParseResult = {
+  deadlineDate?: string;
+  error?: string;
+};
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isClearValue(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === "none" ||
+    normalized === "null" ||
+    normalized === "clear" ||
+    normalized === "no" ||
+    normalized === "no-deadline" ||
+    normalized === "nodeadline"
+  );
+}
+
+export function parseDeadlineDate(value: string): DeadlineDateParseResult {
+  const trimmed = value.trim();
+  if (!DATE_PATTERN.test(trimmed)) {
+    return { error: 'Invalid --deadline value. Use YYYY-MM-DD or "none".' };
+  }
+  return { deadlineDate: trimmed };
+}
+
+export function parseDeadlineUpdate(value: string): DeadlineParseResult {
+  if (isClearValue(value)) {
+    return { deadlineDate: null };
+  }
+  return parseDeadlineDate(value);
+}

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,0 +1,43 @@
+export type LabelsParseResult = {
+  labels?: string[];
+  error?: string;
+};
+
+export function parseLabelsCsv(value: string): LabelsParseResult {
+  const raw = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const labels = Array.from(new Set(raw));
+
+  if (labels.length === 0) {
+    return { error: "--labels must contain at least one label" };
+  }
+
+  return { labels };
+}
+
+export type LabelDelta = {
+  add?: string[];
+  remove?: string[];
+};
+
+export function applyLabelDelta(
+  current: string[],
+  delta: LabelDelta
+): string[] {
+  const set = new Set(current);
+
+  for (const label of delta.add ?? []) {
+    const normalized = label.trim();
+    if (normalized) set.add(normalized);
+  }
+
+  for (const label of delta.remove ?? []) {
+    const normalized = label.trim();
+    if (normalized) set.delete(normalized);
+  }
+
+  return Array.from(set);
+}

--- a/src/move-target.ts
+++ b/src/move-target.ts
@@ -1,0 +1,89 @@
+import type { MoveTaskArgs } from "@doist/todoist-api-typescript";
+
+export type Project = { id: string; name: string };
+export type Section = { id: string; name: string; projectId: string };
+
+export type ResolveMoveTargetInput = {
+  projectName?: string;
+  sectionName?: string;
+  parentId?: string;
+};
+
+export type ResolveMoveTargetResult =
+  | { ok: true; args: MoveTaskArgs; resolved: { projectId?: string; sectionId?: string; parentId?: string } }
+  | { ok: false; error: string };
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+function findBestNameMatch<T extends { name: string }>(
+  items: T[],
+  query: string
+): T | undefined {
+  const q = normalize(query);
+  const exact = items.find((i) => normalize(i.name) === q);
+  if (exact) return exact;
+  return items.find((i) => normalize(i.name).includes(q));
+}
+
+export function resolveMoveTarget(
+  input: ResolveMoveTargetInput,
+  projects: Project[],
+  sections: Section[]
+): ResolveMoveTargetResult {
+  const { projectName, sectionName, parentId } = input;
+
+  if (!projectName && !sectionName && !parentId) {
+    return { ok: false, error: "Must specify --project, --section, or --parent" };
+  }
+
+  if (parentId) {
+    return { ok: true, args: { parentId }, resolved: { parentId } };
+  }
+
+  let projectId: string | undefined;
+  if (projectName) {
+    const project = findBestNameMatch(projects, projectName);
+    if (!project) {
+      return { ok: false, error: `Project not found: ${projectName}` };
+    }
+    projectId = project.id;
+  }
+
+  if (sectionName) {
+    const candidateSections = projectId
+      ? sections.filter((s) => s.projectId === projectId)
+      : sections;
+
+    const matches = candidateSections.filter(
+      (s) => normalize(s.name) === normalize(sectionName)
+    );
+
+    if (!projectId && matches.length > 1) {
+      return {
+        ok: false,
+        error: `Multiple sections named '${sectionName}'. Pass --project to disambiguate.`,
+      };
+    }
+
+    const section =
+      matches[0] ?? findBestNameMatch(candidateSections, sectionName);
+
+    if (!section) {
+      return { ok: false, error: `Section not found: ${sectionName}` };
+    }
+
+    return {
+      ok: true,
+      args: { sectionId: section.id },
+      resolved: { projectId, sectionId: section.id },
+    };
+  }
+
+  if (projectId) {
+    return { ok: true, args: { projectId }, resolved: { projectId } };
+  }
+
+  return { ok: false, error: "Must specify --project, --section, or --parent" };
+}

--- a/tests/deadline.test.js
+++ b/tests/deadline.test.js
@@ -1,0 +1,18 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseDeadlineDate, parseDeadlineUpdate } from "../dist/deadline.js";
+
+test("parseDeadlineDate accepts YYYY-MM-DD", () => {
+  assert.deepEqual(parseDeadlineDate("2026-03-05"), { deadlineDate: "2026-03-05" });
+});
+
+test("parseDeadlineDate rejects non-date", () => {
+  const { error } = parseDeadlineDate("next monday");
+  assert.equal(error, 'Invalid --deadline value. Use YYYY-MM-DD or "none".');
+});
+
+test("parseDeadlineUpdate supports clearing", () => {
+  assert.deepEqual(parseDeadlineUpdate("none"), { deadlineDate: null });
+  assert.deepEqual(parseDeadlineUpdate("null"), { deadlineDate: null });
+  assert.deepEqual(parseDeadlineUpdate("clear"), { deadlineDate: null });
+});

--- a/tests/labels.test.js
+++ b/tests/labels.test.js
@@ -1,0 +1,18 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyLabelDelta, parseLabelsCsv } from "../dist/labels.js";
+
+test("parseLabelsCsv parses and dedupes", () => {
+  const { labels } = parseLabelsCsv("next, waiting, next");
+  assert.deepEqual(labels, ["next", "waiting"]);
+});
+
+test("parseLabelsCsv rejects empty", () => {
+  const { error } = parseLabelsCsv(" ,  ,");
+  assert.equal(error, "--labels must contain at least one label");
+});
+
+test("applyLabelDelta adds and removes", () => {
+  const result = applyLabelDelta(["a", "b"], { add: ["c"], remove: ["b"] });
+  assert.deepEqual(new Set(result), new Set(["a", "c"]));
+});

--- a/tests/move-target.test.js
+++ b/tests/move-target.test.js
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveMoveTarget } from "../dist/move-target.js";
+
+test("resolveMoveTarget prefers section move when both project and section are provided", () => {
+  const result = resolveMoveTarget(
+    { projectName: "Proj", sectionName: "Section A" },
+    [{ id: "p1", name: "Proj" }],
+    [
+      { id: "s1", name: "Section A", projectId: "p1" },
+      { id: "s2", name: "Section A", projectId: "p2" },
+    ]
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.args, { sectionId: "s1" });
+});
+
+test("resolveMoveTarget errors on ambiguous section without project", () => {
+  const result = resolveMoveTarget(
+    { sectionName: "Section A" },
+    [
+      { id: "p1", name: "Proj1" },
+      { id: "p2", name: "Proj2" },
+    ],
+    [
+      { id: "s1", name: "Section A", projectId: "p1" },
+      { id: "s2", name: "Section A", projectId: "p2" },
+    ]
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Multiple sections/);
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   entry: [
     "src/add-order.ts",
     "src/assignee.ts",
+    "src/deadline.ts",
+    "src/labels.ts",
+    "src/move-target.ts",
     "src/cli.ts",
     "src/index.ts",
     "src/task-ordering.ts",


### PR DESCRIPTION
Fixes #6
Fixes #5
Fixes #7

Changes:
- `todoist move` now correctly moves to a section when `--section` is provided (even if `--project` is also provided). Also errors on ambiguous section names without `--project`.
- Add `--deadline YYYY-MM-DD` to `todoist add`.
- Add deadline support to `todoist update` (`--deadline YYYY-MM-DD` or `--deadline none`).
- Add label updates to `todoist update`: `--labels "a,b"` (replace) or `--add-label/--remove-label` (incremental).

Tests:
- Added unit tests for deadline parsing, label parsing/deltas, and move target resolution.

Local verification:
- Created a test project/section and confirmed:
  - add w/ deadline works
  - update add/remove labels works
  - update clear deadline works
  - move -p/-s actually results in sectionId being set